### PR TITLE
En la busqueda hay un limite de 10 por defecto que limita los resultados

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -88,6 +88,7 @@ SimpleJekyllSearch({
   resultsContainer: document.getElementById('results-container'),
   searchResultTemplate: '<article class="box-item"><div class="box-body"><div class="box-barrio"><span class="post-meta">{barrio}, {departamento}</span></div><h3><a class="post-link" href="{url}">{title}</a></h3><p>{actividades}</p></div></article>',
   noResultsText: ("¡No se encontraron resultados!"),
+  limit: 1000,
   json: '/search.json'
 })
 </script>


### PR DESCRIPTION
Encontré que los resultados de la búsqueda se estaban limitando a 10 elementos.
Puse un límite de 1000 para no tener problemas.