### PR TITLE
Mostrar datos de cada organización en su caja

### DIFF
--- a/_includes/details.html
+++ b/_includes/details.html
@@ -1,0 +1,57 @@
+<div class="details__scroll">
+  <div class="details__title">
+    <a href="{{ include.post.url | relative_url }}" target="_blank">Ver detalle</a>
+  </div>
+  <table class="details__table">
+    <tbody>
+      <tr>
+          <td class="title">Actividad:</td>
+          <td>{{include.post.actividades}}</td>
+      </tr>
+      <tr>
+          <td class="title">Departamento:</td>
+          <td>{{include.post.departamento}}</td>
+      </tr>
+      <tr>
+          <td class="title">Barrio:</td>
+          <td>{{include.post.barrio}}</td>
+      </tr>
+      <tr>
+          <td class="title">Dirección:</td>
+          <td>{{include.post.direccion}}</td>
+      </tr>
+      <tr>
+          <td class="title">Teléfono:</td>
+          <td>{{include.post.telefono_contacto}}</td>
+      </tr>
+      <tr>
+          <td class="title">Necesidades:</td>
+          <td>{{include.post.necesidades}}</td>
+      </tr>
+      {% if include.post.otros_contactos != blank and include.post.otros_contactos != "" %}
+      <tr>
+          <td class="title">Otros contactos:</td>
+          <td>{{include.post.otros_contactos}}</td>
+      </tr>
+      {% endif %}
+      {% if include.post.horario != blank and include.post.horario != "" %}
+      <tr>
+          <td class="title">Horario:</td>
+          <td>{{include.post.horario}}</td>
+      </tr>
+      {% endif %}
+      {% if include.post.aclaraciones != blank and include.post.aclaraciones != "" %}
+      <tr>
+          <td class="title">Aclaraciones:</td>
+          <td>{{include.post.aclaraciones}}</td>
+      </tr>
+      {% endif %}
+      {% if include.post.cuenta_bancaria != blank and include.post.cuenta_bancaria != "" %}
+      <tr>
+          <td class="title">Cuenta bancaria:</td>
+          <td>{{include.post.cuenta_bancaria}}</td>
+      </tr>
+      {% endif %}
+    </tbody>
+  </table>
+</div>

--- a/_includes/result.html
+++ b/_includes/result.html
@@ -1,0 +1,21 @@
+<article class="box-item details__container">
+  <div class="box-body">
+    <div class="box-barrio">
+      <span class="post-meta">{{ include.post.barrio }}, {{ include.post.departamento }}</span>
+    </div>
+    <h3>
+      <a class="post-link" data-toggle="#details-{{ forloop.index }}" href="{{ include.post.url | relative_url }}">
+        {{ include.post.title | escape }}
+      </a>
+    </h3>
+    <p>{{ include.post.actividades }}</p>
+    {%- if site.show_excerpts -%}
+      {{ include.post.excerpt }}
+    {%- endif -%}
+  </div>
+
+  <div id="details-{{ forloop.index }}" class="details__box hide">
+    <button class="details__back" data-toggle="#details-{{ forloop.index }}"></button>
+    {% include details.html post=include.post %}
+  </div>
+</article>

--- a/_includes/result_js.html
+++ b/_includes/result_js.html
@@ -1,0 +1,67 @@
+<article class="box-item details__container">
+  <div class="box-body">
+    <div class="box-barrio">
+      <span class="post-meta">{barrio}, {departamento}</span>
+    </div>
+    <h3>
+      <a class="post-link" data-toggle="#details-{index}" href="{url}">
+        {title}
+      </a>
+    </h3>
+    <p>{actividades}</p>
+  </div>
+
+  <div id="details-{index}" class="details__box hide">
+    <button class="details__back" data-toggle="#details-{index}"></button>
+    <div class="details__scroll">
+      <div class="details__title">
+        <a href="{url}" target="_blank">Ver detalle</a>
+      </div>
+      <table class="details__table">
+        <tbody>
+          <tr>
+              <td class="title">Actividad:</td>
+              <td>{actividades}</td>
+          </tr>
+          <tr>
+              <td class="title">Departamento:</td>
+              <td>{departamento}</td>
+          </tr>
+          <tr>
+              <td class="title">Barrio:</td>
+              <td>{barrio}</td>
+          </tr>
+          <tr>
+              <td class="title">Dirección:</td>
+              <td>{direccion}</td>
+          </tr>
+          <tr>
+              <td class="title">Teléfono:</td>
+              <td>{telefono_contacto}</td>
+          </tr>
+          <tr>
+              <td class="title">Necesidades:</td>
+              <td>{necesidades}</td>
+          </tr>
+          <tr>
+              <td class="title">Otros contactos:</td>
+              <td>{otros_contactos}</td>
+          </tr>
+          <tr>
+              <td class="title">Horario:</td>
+              <td>{horario}</td>
+          </tr>
+          <tr>
+              <td class="title">Aclaraciones:</td>
+              <td>{aclaraciones}</td>
+          </tr>
+          <tr>
+              <td class="title">Cuenta bancaria:</td>
+              <td>{cuenta_bancaria}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+  </div>
+</article>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -42,26 +42,9 @@ layout: default
     
     <div id="row" class="row flex-grid">
       {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
-      {%- for post in posts -%}
 
-        <a class="post-link" href="{{ post.url | relative_url }}">
-          <article class="box-item">
-            <div class="box-body">
-              <div class="box-barrio">
-                <span class="post-meta">{{ post.barrio }}, {{ post.departamento }}</span>
-              </div>
-              <h3>
-                <a class="post-link" href="{{ post.url | relative_url }}">
-                  {{ post.title | escape }}
-                </a>
-              </h3>
-              <p>{{ post.actividades }}</p>
-              {%- if site.show_excerpts -%}
-                {{ post.excerpt }}
-              {%- endif -%}
-            </div>
-          </article>
-        </a>
+      {%- for post in posts -%}
+        {% include result.html post=post %}
       {%- endfor -%}
       
     </div>
@@ -190,7 +173,7 @@ filtersMap.set('actividades', document.getElementById("actividad"));
 SimpleJekyllSearch({
   searchInput: document.getElementById('search-input'),
   resultsContainer: document.getElementById('results-container'),
-  searchResultTemplate: '<article class="box-item"><div class="box-body"><div class="box-barrio"><span class="post-meta">{barrio}, {departamento}</span></div><h3><a class="post-link" href="{url}">{title}</a></h3><p>{actividades}</p></div></article>',
+  searchResultTemplate: `{% include result_js.html %}`,
   noResultsText: ("¡No se encontraron resultados!"),
   limit: 1000,
   fuzzy: false,
@@ -198,3 +181,6 @@ SimpleJekyllSearch({
   json: '/search.json'
 })
 </script>
+
+<!-- All home-related code -->
+<script src="js/home.js"></script>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -18,6 +18,10 @@ body {
   font-family: 'PT Sans Narrow', sans-serif;
 }
 
+.hide {
+  display: none !important;
+}
+
 .site-footer {
   border-top: 0;
   background-color: $base-color;
@@ -120,7 +124,7 @@ body {
  min-height:14rem;
  transition:all .3s;
  position:relative;
- cursor:pointer;
+ /* cursor:pointer; Why this? */
  max-width: 350px;
  text-align: left;
 }
@@ -183,4 +187,76 @@ body {
 .colaborar-lists {
   display: inline-block;
   text-align: left;
+}
+
+
+/* --- Details Modal --- */
+
+.details__container {
+  position: relative;
+}
+
+.details__box {
+  position: absolute;
+  top: 5px;
+  bottom: 5px;
+  right: 5px;
+  left: 5px;
+  display: flex;
+  flex-direction: row;
+}
+
+.details__scroll {
+  height: 100%;
+  width: 100%;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  background: $white;
+}
+
+.details__table {
+  margin-bottom: 0;
+  word-break: break-all;
+
+  /* Avoid word break in title cell */
+  td.title {
+    min-width: 95px;
+  }
+}
+
+.details__back {
+  border: 0;
+  margin: 0;
+  padding: 0.25rem;
+  background: $base-color;
+  display: flex;
+  flex-direction: column;
+  font-weight: bold;
+  font-size: 1.25rem;
+  color: $white;
+
+  &:before {
+    content: '\00D7';
+  }
+
+  &:hover {
+    color: $gray-transparent;
+  }
+}
+
+.details__title {
+  padding: 0.25rem;
+  padding-right: 0.5rem;
+  background: $gray-transparent;
+  display: flex;
+  justify-content: flex-end;
+
+  a {
+    font-weight: bold;
+    color: white;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.7'
+services:
+  web:
+    image: ruby:2.7
+    volumes:
+      - '.:/usr/src/app'
+      - 'bundle:/usr/local/bundle'
+    working_dir: /usr/src/app
+    command: ['bundle', 'exec', 'jekyll', 'serve', '-H', '0.0.0.0', '--incremental']
+    ports:
+      - '4000:4000'
+
+volumes:
+  bundle:

--- a/js/home.js
+++ b/js/home.js
@@ -1,0 +1,7 @@
+$(function() {
+	$(document).on('click', '[data-toggle]', function(event) {
+		event.preventDefault();
+		var element = $(this);
+		$(element.data('toggle')).toggleClass('hide');
+	});
+});

--- a/search.json
+++ b/search.json
@@ -3,14 +3,19 @@
 [
   {% for post in site.organizaciones %}
     {
-
+      "index": "{{ forloop.index }}",
       "title"    		: "{{ post.title | escape }}",
       "url"      : "{{ site.baseurl }}{{ post.url }}",
       "departamento"    : "{{ post.departamento }}",
       "barrio" 			: "{{ post.barrio }}",
       "actividades"     : "{{ post.actividades }}",
-      "necesidades"		: "{{ post.necesidades }}"
-
+      "necesidades":"{{ post.necesidades | default: 'Sin especificar' }}",
+      "direccion":"{{ post.direccion | escape | default: 'Sin especificar' }}",
+      "telefono_contacto":"{{ post.telefono_contacto | escape | default: 'Sin especificar' }}",
+      "otros_contactos":"{{ post.otros_contactos | escape | default: 'Sin especificar' }}",
+      "horario":"{{ post.horario | escape | default: 'Sin especificar' }}",
+      "aclaraciones":"{{ post.aclaraciones | escape | default: 'Sin especificar' }}",
+      "cuenta_bancaria":"{{ post.cuenta_bancaria | strip_newlines | escape | default: 'Sin especificar' }}"
     } {% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]


### PR DESCRIPTION
Al hacer clic en el título de la organización se muestra un
modal dentro de la caja con un botón para cerrar
a la izquierda y un vínculo al detalle de la organización
arriba a la derecha.

* Agregar campos a search.json para dar soporte al modal
* Remover pointer por defecto en hover sobre cajas (Propuesta)
* Modularizar el código de un resultado (result.html)
* Modularizar código de template que usa Simple-Jekyll-Search (result_js.html)
* Agregar archivo docker-compose.yml para ejecución en contenedor